### PR TITLE
Fix typo in installation instructions: gbischof -> gwbischof

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ All tools have been implemented and tested ✅
 
 ```bash
 # Clone the repository
-git clone https://github.com/gbischof/free-will-mcp.git
+git clone https://github.com/gwbischof/free-will-mcp.git
 cd free-will-mcp
 
 # Install dependencies


### PR DESCRIPTION
This PR fixes a typo in the installation instructions where `gbischof` should be `gwbischof` in the git clone command.

**Changes:**
- Fixed typo in README.md: `git clone https://github.com/gbischof/free-will-mcp.git` → `git clone https://github.com/gwbischof/free-will-mcp.git`

This typo would cause the installation instructions to fail since the repository name is incorrect.